### PR TITLE
RAPIDCX-16577: Update README.md to explain purpose of public API models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # rapidcx-public-api
-Repository contains public API specification that should be used to integrate with RapidCX platform.
+Repository contains public API public model specifications for RapidCX public API contracts.
+
+View the RapidCX Public API in the [RapidCX Developer Portal](https://docs.developer.rapidcx.engageone.co/).


### PR DESCRIPTION
Jira: RAPIDCX-16577

Scope of this repository was reduced to just host common models for public API contracts. Updated the README.md to reflect the reduced scope.